### PR TITLE
Fixed System.IO.IOException bug and added max file size feature

### DIFF
--- a/src/SauronEye/ArgumentParser.cs
+++ b/src/SauronEye/ArgumentParser.cs
@@ -13,6 +13,7 @@ namespace SauronEye {
         public string[] DefaultFileTypes, DefaultKeywords;
         public bool SearchContents;
         public bool SystemDirs;
+        public UInt64 MaxFileSizeInKB;
         public RegexSearch regexSearcher;
         public DateTime BeforeDate;
         public DateTime AfterDate;
@@ -24,6 +25,7 @@ namespace SauronEye {
             DefaultFileTypes = new string[] { ".docx", ".txt" };
             DefaultKeywords = new string[] { "pass*", "wachtw*" };
             SearchContents = false;
+            MaxFileSizeInKB = 1024; // In kilobytes: 1MB
             SystemDirs = false;
             BeforeDate = DateTime.MinValue;
             AfterDate = DateTime.MinValue;
@@ -47,6 +49,7 @@ namespace SauronEye {
                     currentParameter = "k";
                 } },
                 { "c|contents","Search file contents", c =>  SearchContents = c != null },
+                { "m|maxfilesize=", "Max file size to search contents in, in kilobytes", m => { CheckInteger(m); } },
                 { "b|beforedate=", "Filter files last modified before this date, \n format: yyyy-MM-dd", b => { CheckDate(b, "before"); } },
                 { "a|afterdate=", "Filter files last modified after this date, \n format: yyyy-MM-dd", a => { CheckDate(a, "after"); } },
                 { "s|systemdirs","Search in filesystem directories %APPDATA% and %WINDOWS%", s => SystemDirs = s != null },
@@ -109,6 +112,14 @@ namespace SauronEye {
             }
 
 
+        }
+
+        private void CheckInteger(string maybeInt) {
+            bool isParsable = UInt64.TryParse(maybeInt, out this.MaxFileSizeInKB);
+
+            if (!isParsable) {
+                Console.WriteLine("[!] MaxFileSize is not an Integer, defaulting to 1MB.");
+            }
         }
 
         private void CheckDate(string date, string whichdate) {

--- a/src/SauronEye/Program.cs
+++ b/src/SauronEye/Program.cs
@@ -23,6 +23,7 @@ namespace SauronEye {
             Console.WriteLine("For file types: " + string.Join(", ", ArgumentParser.FileTypes));
             Console.WriteLine("Containing: " + string.Join(", ", ArgumentParser.Keywords));
             Console.WriteLine("Search contents: " + ArgumentParser.SearchContents.ToString());
+            Console.WriteLine("Max file size: " + ArgumentParser.MaxFileSizeInKB.ToString() + " KB");
             Console.WriteLine("Search Program Files directories: " + ArgumentParser.SystemDirs.ToString());
             if (ArgumentParser.BeforeDate != DateTime.MinValue) {
                 Console.WriteLine("Only files before: " + ArgumentParser.BeforeDate.ToString("yyyy-MM-dd") + "\n");
@@ -37,7 +38,7 @@ namespace SauronEye {
             var options = new ParallelOptions { MaxDegreeOfParallelism = ArgumentParser.Directories.Count };
             Parallel.ForEach(ArgumentParser.Directories, options, (dir) => {
                 Console.WriteLine("Searching in parallel: " + dir);
-                var fileSystemSearcher = new FSSearcher(dir, ArgumentParser.FileTypes, ArgumentParser.Keywords, ArgumentParser.SearchContents, ArgumentParser.SystemDirs, ArgumentParser.regexSearcher, ArgumentParser.BeforeDate, ArgumentParser.AfterDate);
+                var fileSystemSearcher = new FSSearcher(dir, ArgumentParser.FileTypes, ArgumentParser.Keywords, ArgumentParser.SearchContents, ArgumentParser.MaxFileSizeInKB, ArgumentParser.SystemDirs, ArgumentParser.regexSearcher, ArgumentParser.BeforeDate, ArgumentParser.AfterDate);
                 fileSystemSearcher.Search();
 
             });

--- a/src/SauronEye/Searcher.cs
+++ b/src/SauronEye/Searcher.cs
@@ -83,12 +83,18 @@ namespace SauronEye {
 
                 }
                 return dirFiles.Concat(Directory.EnumerateFiles(path, searchPattern).Where(fi => EndsWithExtension(fi)));
+
             } catch (UnauthorizedAccessException ex) {
                 return Enumerable.Empty<string>();
+
             } catch (PathTooLongException ex) {
                 // Microsoft solution: https://docs.microsoft.com/en-us/dotnet/standard/io/how-to-enumerate-directories-and-files
                 Console.WriteLine("[!] {0} is too long. Continuing with next directory.", path);
                 return Enumerable.Empty<string>();
+
+            } catch (System.IO.IOException ex) {
+                return Enumerable.Empty<string>();
+
             }
         }
 

--- a/src/SauronEye/Searcher.cs
+++ b/src/SauronEye/Searcher.cs
@@ -151,7 +151,7 @@ namespace SauronEye {
 
         private IEnumerable<string> Directories;
         private List<string> Keywords;
-        private UInt64 MAX_FILE_SIZE; // 1MB
+        private UInt64 MAX_FILE_SIZE;
         private static readonly string[] OfficeExtentions = { ".doc", ".docx", ".xls", ".xlsx" };
         private RegexSearch RegexSearcher;
 
@@ -170,7 +170,7 @@ namespace SauronEye {
                     var fileInfo = new FileInfo(NTdir);
 
                     string fileContents;
-                    if (Convert.ToUInt64(fileInfo.Length) < this.MAX_FILE_SIZE) {
+                    if (Convert.ToUInt64(fileInfo.Length) < 1024 * this.MAX_FILE_SIZE) {
                         if (IsOfficeExtension(fileInfo.Extension)) {
                             try {
                                 var reader = new FilterReader(fileInfo.FullName);
@@ -186,7 +186,7 @@ namespace SauronEye {
 
                         }
                     } else {
-                        Console.WriteLine("[-] File exceeds 1MB file size {0}", fileInfo.FullName.Replace(@"\\?\", ""));
+                        Console.WriteLine("[-] File exceeds max file size {0}", fileInfo.FullName.Replace(@"\\?\", ""));
                     }
                 } catch (PathTooLongException ex) {
                     Console.WriteLine("[-] Path {0} is too long. Skipping.", dir);

--- a/src/SauronEyeTests/UnitTests.cs
+++ b/src/SauronEyeTests/UnitTests.cs
@@ -17,7 +17,7 @@ namespace SauronEyeTests {
             };
             var Regex = new SauronEye.RegexSearch(new List<string> { "pass" } );
             var Keywords = new List<string> { "pass" };
-            var ContentSearcher = new SauronEye.ContentsSearcher(LongDirectories, Keywords, Regex);
+            var ContentSearcher = new SauronEye.ContentsSearcher(LongDirectories, Keywords, Regex, 1024);
             ContentSearcher.Search();
 
             var currentConsoleOut = Console.Out;
@@ -40,7 +40,7 @@ namespace SauronEyeTests {
             var Directories = new List<string> { "" };
             var Regex = new SauronEye.RegexSearch(new List<string> { "pass" });
             var Keywords = new List<string> { "pass" };
-            var ContentSearcher = new SauronEye.ContentsSearcher(Directories, Keywords, Regex);
+            var ContentSearcher = new SauronEye.ContentsSearcher(Directories, Keywords, Regex, 1024);
 
             var testCases = new Dictionary<string, string>();
             testCases.Add("this is a long string containing a password", "...g containing a password... ");


### PR DESCRIPTION
* **Bug:** a System.IO.IOException could be thrown by the FSSearcher class but not caught
* **Feature:** the max file size of 1MB was hardcoded and is now an customizable (with `-m`) unsigned 64-bits integer