### PR TITLE
Bug on systems with UseLegacyPathHandling enabled

### DIFF
--- a/src/SauronEye/Searcher.cs
+++ b/src/SauronEye/Searcher.cs
@@ -191,8 +191,15 @@ namespace SauronEye {
         // Searches the contents of filtered files. Does not care about exceptions.
         public void Search() {
             foreach (String dir in Directories) {
-                try { 
-                    var fileInfo = new FileInfo(ConvertToNTPath(dir));
+                try {
+                    bool usingLegacyPathHandling = false;
+                    AppContext.TryGetSwitch("Switch.System.IO.UseLegacyPathHandling", out usingLegacyPathHandling);
+                    var dirToCheck = dir;
+                    if (!usingLegacyPathHandling)
+                    {
+                        dirToCheck = ConvertToNTPath(dir);
+                    }
+                    var fileInfo = new FileInfo(dirToCheck);
 
                     string fileContents;
                     if (Convert.ToUInt64(fileInfo.Length) < 1024 * this.MAX_FILE_SIZE) {


### PR DESCRIPTION
This bug occured on systems which have the UseLegacyPathHandling option enabled. If that's the case, the FileInfo constructor handles the PathName differently, which results in an ArgumentException with "Invalid characters in path" as message. 

To enable this option for testing purposes, you can add 
```
<runtime>
    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=true" />
</runtime>
```

to SauronEye.exe.config file. 

This PR fixes this by checking the value of `UseLegacyPathHandling` first. If LegacyPathHandling is enabled, it skips the conversion to NTPath. If it's not set, the code assumes it's false (i.e. disabled). 

The `PrettyPrintNTPath` isn't impacted by whether or not an NT path is used. 
